### PR TITLE
Need install ca-certificates for git submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Several standard packages are needed to build the toolchain.
 
 On Ubuntu, executing the following command should suffice:
 
-    $ sudo apt-get install autoconf automake autotools-dev curl python3 libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev
+    $ sudo apt-get install autoconf automake autotools-dev curl python3 libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev ca-certificates
 
 On Fedora/CentOS/RHEL OS, executing the following command should suffice:
 


### PR DESCRIPTION
Some git submodules require `ca-certificates` package to be installed. Tested on Ubuntu 20.04 only.

<details>
<summary>error log </summary>

```
$ make linux

cd /home/dkurt/riscv-gnu-toolchain && \
flock `git rev-parse --git-dir`/config git submodule init /home/dkurt/riscv-gnu-toolchain/gcc/ && \
flock `git rev-parse --git-dir`/config git submodule update /home/dkurt/riscv-gnu-toolchain/gcc/
cd /home/dkurt/riscv-gnu-toolchain && \
flock `git rev-parse --git-dir`/config git submodule init /home/dkurt/riscv-gnu-toolchain/glibc/ && \
flock `git rev-parse --git-dir`/config git submodule update /home/dkurt/riscv-gnu-toolchain/glibc/
cd /home/dkurt/riscv-gnu-toolchain && \
flock `git rev-parse --git-dir`/config git submodule init /home/dkurt/riscv-gnu-toolchain/binutils/ && \
flock `git rev-parse --git-dir`/config git submodule update /home/dkurt/riscv-gnu-toolchain/binutils/
rm -rf stamps/build-gdb-linux build-gdb-linux
mkdir build-gdb-linux
cd build-gdb-linux && CC_FOR_TARGET=riscv64-unknown-linux-gnu-gcc /home/dkurt/riscv-gnu-toolchain/riscv-gdb/configure \
        --target=riscv64-unknown-linux-gnu \
         \
        --prefix=/opt/riscv \
        --with-sysroot=/opt/riscv/sysroot \
        --disable-multilib \
         \
        --disable-werror \
        --disable-nls \
        --with-expat=yes  \
        --enable-gdb \
        --disable-gas \
        --disable-binutils \
        --disable-ld \
        --disable-gold \
        --disable-gprof
Cloning into '/home/dkurt/riscv-gnu-toolchain/gcc'...
fatal: unable to access 'https://gcc.gnu.org/git/gcc.git/': server certificate verification failed. CAfile: none CRLfile: none
fatal: clone of 'https://gcc.gnu.org/git/gcc.git' into submodule path '/home/dkurt/riscv-gnu-toolchain/gcc' failed
Failed to clone 'gcc'. Retry scheduled
Cloning into '/home/dkurt/riscv-gnu-toolchain/gcc'...
fatal: unable to access 'https://gcc.gnu.org/git/gcc.git/': server certificate verification failed. CAfile: none CRLfile: none
fatal: clone of 'https://gcc.gnu.org/git/gcc.git' into submodule path '/home/dkurt/riscv-gnu-toolchain/gcc' failed
Failed to clone 'gcc' a second time, aborting
make: *** [Makefile:274: /home/dkurt/riscv-gnu-toolchain/gcc/.git] Error 1
make: *** Waiting for unfinished jobs....
checking build system type... Cloning into '/home/dkurt/riscv-gnu-toolchain/glibc'...
x86_64-pc-linux-gnu
checking host system type... x86_64-pc-linux-gnu
checking target system type... riscv64-unknown-linux-gnu
fatal: unable to access 'https://sourceware.org/git/glibc.git/': server certificate verification failed. CAfile: none CRLfile: none
fatal: clone of 'https://sourceware.org/git/glibc.git' into submodule path '/home/dkurt/riscv-gnu-toolchain/glibc' failed
Failed to clone 'glibc'. Retry scheduled
checking for a BSD-compatible install... Cloning into '/home/dkurt/riscv-gnu-toolchain/glibc'...
/usr/bin/install -c
checking whether ln works... yes
checking whether ln -s works... yes
checking for a sed that does not truncate output... /usr/bin/sed
checking for gawk... /usr/bin/gawk
fatal: unable to access 'https://sourceware.org/git/glibc.git/': server certificate verification failed. CAfile: none CRLfile: none
fatal: clone of 'https://sourceware.org/git/glibc.git' into submodule path '/home/dkurt/riscv-gnu-toolchain/glibc' failed
Failed to clone 'glibc' a second time, aborting
make: *** [Makefile:274: /home/dkurt/riscv-gnu-toolchain/glibc/.git] Error 1
configure: WARNING: neither ld nor gold are enabled
checking for gdbserver support... no
checking for gcc... gcc
checking whether the C compiler works... Cloning into '/home/dkurt/riscv-gnu-toolchain/binutils'...
yes
checking for C compiler default output file name... a.out
checking for suffix of executables... fatal: unable to access 'https://sourceware.org/git/binutils-gdb.git/': server certificate verification failed. CAfile: none CRLfile: none
fatal: clone of 'https://sourceware.org/git/binutils-gdb.git' into submodule path '/home/dkurt/riscv-gnu-toolchain/binutils' failed
Failed to clone 'binutils'. Retry scheduled

Cloning into '/home/dkurt/riscv-gnu-toolchain/binutils'...
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... fatal: unable to access 'https://sourceware.org/git/binutils-gdb.git/': server certificate verification failed. CAfile: none CRLfile: none
fatal: clone of 'https://sourceware.org/git/binutils-gdb.git' into submodule path '/home/dkurt/riscv-gnu-toolchain/binutils' failed
Failed to clone 'binutils' a second time, aborting
make: *** [Makefile:274: /home/dkurt/riscv-gnu-toolchain/binutils/.git] Error 1
```

</details>